### PR TITLE
fixed binding.gyp syntax errors

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,11 +15,11 @@
 						"AdditionalLibraryDirectories": "$(LIBPROTOBUF)/lib"
 					}
 				}
-			}, { # on linux and mac
+			}, {
 				"libraries": [
 					"-lprotobuf"
 				]
-			}],
+			}]
 		]
 	}]
 }


### PR DESCRIPTION
Since the syntax errors in bindings.gyp made node-gyp throw errors instead of building, I decided to remove them.
Now, node-protobuf builds successfully with node-gyp.

I hope you pull in this fix, because installing the rethinkdb module fails because of the errors while building.
