### PR TITLE
Remove unnecessary check in conditional

### DIFF
--- a/protobuf.cpp
+++ b/protobuf.cpp
@@ -89,7 +89,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
   const EnumValueDescriptor *enumValue = NULL;
   bool repeated = field->is_repeated();
 
-  if (field != NULL && *val != NULL) {
+  if (*val != NULL) {
     switch (field->cpp_type()) {
       case FieldDescriptor::CPPTYPE_INT32: {
         if (repeated)


### PR DESCRIPTION
Either line 90 can dereference a null pointer or the extra check on line 92 is unnecessary, I am assuming the latter.

Issue(s) found via [cppcheck](http://cppcheck.sourceforge.net/).
