### PR TITLE
Minimum node gypsy file required for working compile (for me)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,33 +16,14 @@
 					}
 				}
 			}],
-			["OS == 'mac'", {
+            ["OS == 'mac'", {
                 "libraries": [
                     "-lprotobuf"
                 ],
                 "xcode_settings": {
-                    "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-                    "OTHER_CFLAGS": [
-                        "-g",
-                        "-mmacosx-version-min=10.7",
-                        "-std=c++11",
-                        "-stdlib=libc++",
-                        "-O3",
-                        "-D__STDC_CONSTANT_MACROS",
-                        "-D_FILE_OFFSET_BITS=64",
-                        "-D_LARGEFILE_SOURCE",
-                        "-Wall"
-                    ],
+                    "MACOSX_DEPLOYMENT_TARGET": "10.7",
                     "OTHER_CPLUSPLUSFLAGS": [
-                        "-g",
-                        "-mmacosx-version-min=10.7",
-                        "-std=c++11",
-                        "-stdlib=libc++",
-                        "-O3",
-                        "-D__STDC_CONSTANT_MACROS",
-                        "-D_FILE_OFFSET_BITS=64",
-                        "-D_LARGEFILE_SOURCE",
-                        "-Wall"
+                        "-stdlib=libc++"
                     ]
                 }
             }],


### PR DESCRIPTION
After a comment from @tlbtlbtlb I reviewed the gypsy settings, and pared them down to the minimum it took for me to make a working compile on my system. Hopefully it's the same for others! 

Like I said in the initial PR, I'm not a C++/Xcode pro, so keeping things simple seems like a smarter strategy for me. :)

I'll try to get a simple grunt-based test in a future PR. Had a bit of a time recreating one.
