### PR TITLE
Fixed null optional strings serialized to "null"

### DIFF
--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -7,6 +7,9 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 	bool repeated = field->is_repeated();
 
 	if (*val != NULL) {
+		if (field->is_optional() && val->IsNull())
+			return;
+		
 		switch (field->cpp_type()) {
 			case FieldDescriptor::CPPTYPE_INT32: {
 				if (repeated)

--- a/test/test.js
+++ b/test/test.js
@@ -47,6 +47,20 @@ describe("Basic", function() {
 				pb.parse(buffer, "I don't exist")
 			}, Error)
 		})
+
+		it("Should ignore optional null fields", function() {
+			var objWithNull = {
+				"name": "test",
+				"n64": 123,
+				"value": null
+			}
+
+			var buffer = pb.serialize(objWithNull, "Test")
+			var parsed = pb.parse(buffer, "Test")
+
+			delete objWithNull.value;
+			assert.deepEqual(objWithNull, parsed)
+		})
 	})
 })
 


### PR DESCRIPTION
node-protobuf currently serializes null strings as "null". I think this is error prone and a better solution would be to ignore such a field.

Unfortunately (unless I am mistaken), protobuf does not have a semantic for null values, making this solution only valid for optional fields.

This fix does not handle required fields. I suppose the correct behaviour would be to throw an exception in case a required field is set to null.
