### PR TITLE
Fixed undefined optional strings serialized to "undefined"

### DIFF
--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -7,7 +7,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 	bool repeated = field->is_repeated();
 
 	if (*val != NULL) {
-		if (field->is_optional() && val->IsNull())
+		if (field->is_optional() && (val->IsNull() || val->IsUndefined()))
 			return;
 		
 		switch (field->cpp_type()) {

--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,20 @@ describe("Basic", function() {
 			delete objWithNull.value;
 			assert.deepEqual(objWithNull, parsed)
 		})
+
+		it("Should ignore optional undefined fields", function() {
+			var objWithNull = {
+				"name": "test",
+				"n64": 123,
+				"value": undefined
+			}
+			
+			var buffer = pb.serialize(objWithNull, "Test")
+			var parsed = pb.parse(buffer, "Test")
+
+			delete objWithNull.value;
+			assert.deepEqual(objWithNull, parsed)
+		})
 	})
 })
 


### PR DESCRIPTION
Similar to the other fix, found out that undefined fields were serialized to the "undefined" string.
