### PR TITLE
Fixed deprecation warning

### DIFF
--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -84,11 +84,10 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 				break;
 			case FieldDescriptor::CPPTYPE_ENUM:
 				// TODO: possible memory leak?
-				size_t count;
 				enumValue =
 					val->IsNumber() ?
 						field->enum_type()->FindValueByNumber(val->Int32Value()) :
-						field->enum_type()->FindValueByName(NanCString(val, &count));
+						field->enum_type()->FindValueByName(*NanAsciiString(val));
 
 				if (enumValue != NULL) {
 					if (repeated)


### PR DESCRIPTION
NanCString is depreacted in nan 1.3
  CXX(target) Release/obj.target/protobuf/src/serialize.o
../src/serialize.cpp:91:43: warning: 'NanCString' is deprecated [-Wdeprecated-declarations]
                                                field->enum_type()->FindValueByName(NanCString(val, &count));
                                                                                    ^
../node_modules/nan/nan.h:2285:33: note: 'NanCString' declared here
NAN_DEPRECATED NAN_INLINE char\* NanCString(
                                ^
1 warning generated.
