### PR TITLE
Fix include of dependencies so that breaking changes don't get used automatically.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
   "main": "protobuf.js",
   "repository": "https://github.com/fuwaneko/node-protobuf",
   "dependencies": {
-    "bindings": ">=1.2.1",
-    "nan": ">=1.3.0"
+    "bindings": "^1.2.1",
+    "nan": "^1.3.0"
   },
   "engines": [
     "node >= 0.10.0"
   ],
   "licence": "MIT",
   "devDependencies": {
-    "grunt": ">=0.4.5",
-    "grunt-release": ">=0.7.0",
-    "mocha": ">=1.20.1"
+    "grunt": "^0.4.5",
+    "grunt-release": "^0.7.0",
+    "mocha": "^1.20.1"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha ./test/ -R spec"


### PR DESCRIPTION
As NaN 2.0.0 was released on July 31st node-protobuf stopped installing successfully. This is a quick patch for the issue. Maybe it would worth considering to adjust the package to NaN 2.0.0 but till that this PR restores the usability of the package.