### PR TITLE
build: fix build on Solaris

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,14 +2,16 @@
 	"targets": [{
 		"target_name": "protobuf",
 		"sources": [ "./src/init.cpp", "./src/native.cpp", "./src/parse.cpp", "./src/serialize.cpp" ],
+		"include_dirs": [
+			"<!(node -e \"require('nan')\")"
+		],
 		"conditions": [
 			["OS == 'win'", {
 				"libraries": [
 					"-llibprotobuf.lib"
 				],
 				"include_dirs": [
-					"$(LIBPROTOBUF)/include",
-					"<!(node -e \"require('nan')\")"
+					"$(LIBPROTOBUF)/include"
 				],
 				"msvs_settings": {
 					"VCLinkerTool": {
@@ -22,9 +24,6 @@
 					"-lprotobuf",
 					"-L/usr/local/lib"
 				],
-				"include_dirs": [
-					"<!(node -e \"require('nan')\")"
-				],
 				"xcode_settings": {
 					"MACOSX_DEPLOYMENT_TARGET": "10.7",
 					"OTHER_CPLUSPLUSFLAGS": [
@@ -36,9 +35,6 @@
 			["OS == 'linux'", {
 				"libraries": [
 					"-lprotobuf"
-				],
-				"include_dirs": [
-					"<!(node -e \"require('nan')\")"
 				]
 			}]
 		]


### PR DESCRIPTION
The current binding.gyp file adds the same NAN headers directory to the
compiler's command line for Linux, Windows and OSX, but not for Solaris.

This results in node-protobuf not building on Solaris and platforms
derived from Solaris, like SmartOS.

This change fixes this problem by always adding NAN's headers directory
to the compiler's command line, regardless of the platform.