### PR TITLE
made compliant with protobuf 3.0.0

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,7 @@
 				}
 			}],
 			["OS == 'linux'", {
+				"cflags_cc!": [ "-fno-rtti" ],
 				"libraries": [
 					"-lprotobuf"
 				]


### PR DESCRIPTION
hi,

i have tested new version of protobuf (3.0.0) library and they have changed header files which conflict with default flags for node.gyp (-fno_rtti flag). 

bellow is the log of build before the change.

Signed-off-by: itavy <itavyg@gmail.com>


```
$ CXXFLAGS="-I/opt/protobuf/include -pthread" LDFLAGS="-L/opt/protobuf/lib -lprotobuf -pthread  -lpthread" /home/dev/npm/bin/npm install
npm WARN package.json node-protobuf@1.2.5 No license field.

> node-protobuf@1.2.5 install /home/dev/node-protobuf
> node-gyp rebuild

make: Entering directory `/home/dev/node-protobuf/build'
  CXX(target) Release/obj.target/protobuf/src/init.o
In file included from /opt/protobuf/include/google/protobuf/message.h:118:0,
                 from /opt/protobuf/include/google/protobuf/dynamic_message.h:46,
                 from ../src/common.h:9,
                 from ../src/init.cpp:1:
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternalRawArray(size_t)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:617:25: note: in expansion of macro ‘RTTI_TYPE_ID’
         AllocateAligned(RTTI_TYPE_ID(T), sizeof(T) * num_elements));
                         ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:622:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T))) T();
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:631:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T))) T(arg);
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:641:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T))) T(arg1, arg2);
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:653:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&, const Arg4&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:668:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&, const Arg4&, const Arg5&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:684:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&, const Arg4&, const Arg5&, const Arg6&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:701:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&, const Arg4&, const Arg5&, const Arg6&, const Arg7&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:719:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
/opt/protobuf/include/google/protobuf/arena.h: In member function ‘T* google::protobuf::Arena::CreateInternal(bool, const Arg1&, const Arg2&, const Arg3&, const Arg4&, const Arg5&, const Arg6&, const Arg7&, const Arg8&)’:
/opt/protobuf/include/google/protobuf/arena.h:152:41: error: cannot use typeid with -fno-rtti
 #define RTTI_TYPE_ID(type) (&typeid(type))
                                         ^
/opt/protobuf/include/google/protobuf/arena.h:739:33: note: in expansion of macro ‘RTTI_TYPE_ID’
     T* t = new (AllocateAligned(RTTI_TYPE_ID(T), sizeof(T)))
                                 ^
In file included from ../src/init.cpp:1:0:
../src/common.h: At global scope:
../src/common.h:19:13: warning: ‘preserve_int64’ defined but not used [-Wunused-variable]
 static bool preserve_int64 = false;
             ^
make: *** [Release/obj.target/protobuf/src/init.o] Error 1
make: Leaving directory `/home/dev/node-protobuf/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/dev/npm/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at ChildProcess.EventEmitter.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:797:12)
gyp ERR! System Linux 3.13.0-62-generic
gyp ERR! command "node" "/home/dev/npm/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/dev/node-protobuf
gyp ERR! node -v v0.10.25
gyp ERR! node-gyp -v v2.0.2
gyp ERR! not ok 

npm ERR! Linux 3.13.0-62-generic
npm ERR! argv "node" "/home/dev/npm/bin/npm" "install"
npm ERR! node v0.10.25
npm ERR! npm  v2.14.1
npm ERR! code ELIFECYCLE
npm ERR! node-protobuf@1.2.5 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the node-protobuf@1.2.5 install script 'node-gyp rebuild'.
npm ERR! This is most likely a problem with the node-protobuf package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls node-protobuf
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/dev/node-protobuf/npm-debug.log
```