### PR TITLE
Fix crash mentioned in ticket #53

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -106,7 +106,7 @@ Handle<Value> ParseField(const google::protobuf::Message &message, const Reflect
 			else
 				value = r->GetString(message, field);
 			if (field->type() == FieldDescriptor::TYPE_BYTES)
-				v = Nan::NewBuffer(const_cast<char *>(value.data()), value.length()).ToLocalChecked();
+			    v = Nan::CopyBuffer(const_cast<char *>(value.data()), value.length()).ToLocalChecked();
 			else
 				v = Nan::New<String>(value.c_str()).ToLocalChecked();
 			break;


### PR DESCRIPTION
The Nan update for node v4.2.1 caused a crash on garbage collection due to misuse of Nan::NewBuffer.

According to the [Nan documentation](https://github.com/nodejs/nan/blob/master/doc/buffers.md#api_nan_new_buffer): 
> Note that when creating a Buffer using Nan::NewBuffer() and an existing char*, it is assumed that the ownership of the pointer is being transferred to the new Buffer for management. 
