### PR TITLE
Enable install even if protobuf is not installed to /usr/local

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,17 +3,18 @@
 		"target_name": "protobuf",
 		"sources": [ "./src/init.cpp", "./src/native.cpp", "./src/parse.cpp", "./src/serialize.cpp" ],
 		"include_dirs": [
-			"<!(node -e \"require('nan')\")"
+			"<!(node -e \"require('nan')\")",
+            "$(LIBPROTOBUF)/include"
 		],
+        'libraries': [
+            "-L$(LIBPROTOBUF)/lib"
+        ],
 		"cflags" : [ "-Ofast", "-mtune=native", "-ffast-math", "-funroll-loops", "-fomit-frame-pointer", "-std=c++11", "-pthread", "-static", "-I../../" ],
 		"cflags_cc" : [ "-Ofast", "-mtune=native", "-ffast-math", "-funroll-loops", "-fomit-frame-pointer", "-std=c++11", "-pthread", "-static", "-I../../" ],
 		"conditions": [
 			["OS == 'win'", {
 				"libraries": [
 					"-llibprotobuf.lib"
-				],
-				"include_dirs": [
-					"$(LIBPROTOBUF)/include"
 				],
 				"msvs_settings": {
 					"VCLinkerTool": {


### PR DESCRIPTION
On Linux and OSX it is very hard to install node-protobuf if the protocol buffers package is installed to somewhere other than the default /usr/local folder. 

Although there is a workaround of creating an include.gypi in ~/.gyp but I think it is more convenient to use by setting LIBPROTOBUF environment variable correctly.