### PR TITLE
Support typed arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ Accepts optional callback parameter which is essentially a function in Node.js c
 
 ### Parse
 
-**Protobuf.parse(buffer, schema, [callback])**
+**Protobuf.parse(buffer, schema, [callback, limit, warn])**
 
 Parses Buffer (or UInt8Array for example, just anything that is binary data array) according to schema.
 
 Accepts optional callback parameter which is essentially a function in Node.js callback style, i.e. function(error, result) {}. In case of exceptions (see below) they are passed as first parameter to callback.
+
+Optional limit argument allows to set the maximum message limit. If the optional warn argument is not set, the warning threshold is set to limit/2.
 
 - Returns plain object
 - Throws if first argument isn't a Buffer

--- a/protobuf.js
+++ b/protobuf.js
@@ -42,13 +42,15 @@ pb_wrapper.prototype.parse = function() {
 	var buffer = arguments[0]
 	var schema = arguments[1]
 	var callback = arguments[2] || null
+	var limit = arguments[3] | 0
+	var warn = arguments[4] | 0
 	var native = this.native
 
 	if (!Buffer.isBuffer(buffer))
 		throw new Error("First argument must be a Buffer")
 
 	if (callback === null) {
-		var result = native.parse(buffer, schema)
+		var result = native.parse(buffer, schema, limit, warn)
 		if (result === null)
 			throw new Error("Unexpected error while parsing " + schema)
 		else
@@ -56,7 +58,7 @@ pb_wrapper.prototype.parse = function() {
 	} else
 		process.nextTick(function() {
 			try {
-				var result = native.parse(buffer, schema)
+			        var result = native.parse(buffer, schema, limit, warn)
 				callback(null, result)
 			} catch (e) {
 				callback(e, null)

--- a/src/common.h
+++ b/src/common.h
@@ -12,6 +12,8 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/service.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/io/coded_stream.h>
 #include <string>
 
 using namespace google::protobuf;

--- a/src/native.cpp
+++ b/src/native.cpp
@@ -126,7 +126,7 @@ NAN_METHOD(NativeProtobuf::Parse) {
 	bool parseResult = message->ParseFromCodedStream(&coded_stream);
 
 	if (parseResult) {
-	        Local<Object> ret = ParsePart(buffer_obj->GetIsolate(), *message, self->preserve_int64);
+	        Local<Object> ret = ParsePart(Isolate::GetCurrent(), *message, self->preserve_int64);
 		delete message;
 		info.GetReturnValue().Set(ret);
 	} else {

--- a/src/native.cpp
+++ b/src/native.cpp
@@ -126,7 +126,7 @@ NAN_METHOD(NativeProtobuf::Parse) {
 	bool parseResult = message->ParseFromCodedStream(&coded_stream);
 
 	if (parseResult) {
-		Local<Object> ret = ParsePart(*message, self->preserve_int64);
+	        Local<Object> ret = ParsePart(buffer_obj->GetIsolate(), *message, self->preserve_int64);
 		delete message;
 		info.GetReturnValue().Set(ret);
 	} else {

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -2,7 +2,7 @@
 #include "parse.h"
 
 bool NewTypedArray(Local<Object>& v, Isolate *isolate, const FieldDescriptor *field, int size) {
-#if NODE_MAJOR_VERSION > 0
+#if NODE_MAJOR_VERSION > 0 || NODE_MINOR_VERSION > 11
         Local<ArrayBuffer> a;
 	switch (field->cpp_type()) {
 	case FieldDescriptor::CPPTYPE_INT32:

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -2,6 +2,7 @@
 #include "parse.h"
 
 bool NewTypedArray(Local<Object>& v, Isolate *isolate, const FieldDescriptor *field, int size) {
+#if NODE_MAJOR_VERSION > 0
         Local<ArrayBuffer> a;
 	switch (field->cpp_type()) {
 	case FieldDescriptor::CPPTYPE_INT32:
@@ -23,6 +24,7 @@ bool NewTypedArray(Local<Object>& v, Isolate *isolate, const FieldDescriptor *fi
 	default:
 	        break;
 	}
+#endif
 	return false;
 }
 

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -160,7 +160,7 @@ Local<Object> ParsePart(Isolate *isolate, const google::protobuf::Message &messa
 			if (field->is_repeated()) {
 				int size = r->FieldSize(message, field);
 				Local<Object> typedArray;
-                                if (NewTypedArray(typedArray, isolate, field, size)) {
+                                if (size > 0 && NewTypedArray(typedArray, isolate, field, size)) {
 				        for (int i = 0; i < size; i++)
 					        typedArray->Set(i, ParseField(isolate, message, r, field, i, preserve_int64));
 					v = typedArray;

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,7 +1,7 @@
 #ifndef PARSE_H
 #define PARSE_H
 
-Handle<Value> ParseField(const google::protobuf::Message &message, const Reflection *r, const FieldDescriptor *field, int index, bool preserve_int64);
-Local<Object> ParsePart(const google::protobuf::Message &message, bool preserve_int64);
+Local<Value> ParseField(Isolate *isolate, const google::protobuf::Message &message, const Reflection *r, const FieldDescriptor *field, int index, bool preserve_int64);
+Local<Object> ParsePart(Isolate *isolate, const google::protobuf::Message &message, bool preserve_int64);
 
 #endif

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -2,7 +2,7 @@
 
 #include "serialize.h"
 
-void SerializeField(google::protobuf::Message *message, const Reflection *r, const FieldDescriptor *field, Handle<Value> val, bool preserve_int64) {
+void SerializeField(google::protobuf::Message *message, const Reflection *r, const FieldDescriptor *field, Local<Value> val, bool preserve_int64) {
 	const EnumValueDescriptor *enumValue = NULL;
 	bool repeated = field->is_repeated();
 
@@ -21,7 +21,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 			case FieldDescriptor::CPPTYPE_INT64:
 				if (repeated)
 					if (preserve_int64 && val->IsArray()) {
-						Handle<Object> n64_array = val->ToObject();
+						Local<Object> n64_array = val->ToObject();
 						uint64 n64;
 						uint32 hi = n64_array->Get(0)->Uint32Value(), lo = n64_array->Get(1)->Uint32Value();
 						n64 = ((uint64)hi << 32) + (uint64)lo;
@@ -34,7 +34,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 						r->AddInt64(message, field, val->NumberValue());
 				else
 					if (preserve_int64 && val->IsArray()) {
-						Handle<Object> n64_array = val->ToObject();
+						Local<Object> n64_array = val->ToObject();
 						uint64 n64;
 						uint32 hi = n64_array->Get(0)->Uint32Value(), lo = n64_array->Get(1)->Uint32Value();
 						n64 = ((uint64)hi << 32) + (uint64)lo;
@@ -55,7 +55,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 			case FieldDescriptor::CPPTYPE_UINT64:
 				if (repeated)
 					if (preserve_int64 && val->IsArray()) {
-						Handle<Object> n64_array = val->ToObject();
+						Local<Object> n64_array = val->ToObject();
 						uint64 n64;
 						uint32 hi = n64_array->Get(0)->Uint32Value(), lo = n64_array->Get(1)->Uint32Value();
 						n64 = ((uint64)hi << 32) + (uint64)lo;
@@ -68,7 +68,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 						r->AddUInt64(message, field, val->NumberValue());
 				else
 					if (preserve_int64 && val->IsArray()) {
-						Handle<Object> n64_array = val->ToObject();
+						Local<Object> n64_array = val->ToObject();
 						uint64 n64;
 						uint32 hi = n64_array->Get(0)->Uint32Value(), lo = n64_array->Get(1)->Uint32Value();
 						n64 = ((uint64)hi << 32) + (uint64)lo;
@@ -123,7 +123,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 				break;
 			case FieldDescriptor::CPPTYPE_STRING:
 				if (Buffer::HasInstance(val)) {
-					Handle<Object> buf = val->ToObject();
+					Local<Object> buf = val->ToObject();
 					if (repeated)
 						r->AddString(message, field, std::string(Buffer::Data(buf), Buffer::Length(buf)));
 					else
@@ -132,13 +132,13 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 				}
 
 				if (val->IsObject()) {
-					Handle<Object> val2 = val->ToObject();
-					Handle<Value> converter = val2->Get(Nan::New<String>("toProtobuf").ToLocalChecked());
+					Local<Object> val2 = val->ToObject();
+					Local<Value> converter = val2->Get(Nan::New<String>("toProtobuf").ToLocalChecked());
 					if (converter->IsFunction()) {
-						Handle<Function> toProtobuf = Handle<Function>::Cast(converter);
-						Handle<Value> ret = toProtobuf->Call(val2,0,NULL);
+						Local<Function> toProtobuf = Local<Function>::Cast(converter);
+						Local<Value> ret = toProtobuf->Call(val2,0,NULL);
 						if (Buffer::HasInstance(ret)) {
-							Handle<Object> buf = ret->ToObject();
+							Local<Object> buf = ret->ToObject();
 							if (repeated)
 								r->AddString(message, field, std::string(Buffer::Data(buf), Buffer::Length(buf)));
 							else
@@ -158,7 +158,7 @@ void SerializeField(google::protobuf::Message *message, const Reflection *r, con
 	}
 }
 
-int SerializePart(google::protobuf::Message *message, Handle<Object> subj, bool preserve_int64) {
+int SerializePart(google::protobuf::Message *message, Local<Object> subj, bool preserve_int64) {
 	// get a reflection
 	const Reflection *r = message->GetReflection();
 	const Descriptor *d = message->GetDescriptor();
@@ -173,19 +173,19 @@ int SerializePart(google::protobuf::Message *message, Handle<Object> subj, bool 
 
 	// build a reflection
 	// get properties of passed object
-	Handle<Array> properties = subj->GetPropertyNames();
+	Local<Array> properties = subj->GetPropertyNames();
 	uint32_t len = properties->Length();
 
 	// check that all required properties are present
 	for (uint32_t i = 0; i < required.size(); i++) {
-		Handle<String> key = Nan::New<String>(required.at(i).c_str()).ToLocalChecked();
+		Local<String> key = Nan::New<String>(required.at(i).c_str()).ToLocalChecked();
 		if (!subj->Has(key))
 			return -1;
 	}
 
 	for (uint32_t i = 0; i < len; i++) {
-		Handle<Value> property = properties->Get(i);
-		Handle<String> property_s = property->ToString();
+		Local<Value> property = properties->Get(i);
+		Local<String> property_s = property->ToString();
 
 		if (*property_s == NULL)
 			continue;
@@ -196,18 +196,21 @@ int SerializePart(google::protobuf::Message *message, Handle<Object> subj, bool 
 		const FieldDescriptor *field = d->FindFieldByName(propertyName);
 		if (field == NULL) continue;
 
-		Handle<Value> val = subj->Get(property);
+		Local<Value> val = subj->Get(property);
 
 		if (field->is_repeated()) {
-			if (!val->IsArray())
-				continue;
-
-			Handle<Array> array = val.As<Array>();
-			int len = array->Length();
-
-			for (int i = 0; i < len; i++)
-				SerializeField(message, r, field, array->Get(i), preserve_int64);
-
+		        uint32_t len;
+			Local<Object> array;
+		        if (val->IsArray()) {
+			        len = val.As<Array>()->Length();
+			} else if (val->IsTypedArray()) {
+			        len = val.As<TypedArray>()->Length();
+			} else {
+			        continue;
+			}
+			array = val.As<Object>();
+			for (uint32_t i = 0; i < len; i++)
+			        SerializeField(message, r, field, array->Get(i), preserve_int64);
 		} else {
 			SerializeField(message, r, field, val, preserve_int64);
 		}

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -203,7 +203,7 @@ int SerializePart(google::protobuf::Message *message, Local<Object> subj, bool p
 			Local<Object> array;
 		        if (val->IsArray()) {
 			        len = val.As<Array>()->Length();
-#if NODE_MAJOR_VERSION > 0
+#if NODE_MAJOR_VERSION > 0 || NODE_MINOR_VERSION > 11
 			} else if (val->IsTypedArray()) {
 			        len = val.As<TypedArray>()->Length();
 #endif

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -203,8 +203,10 @@ int SerializePart(google::protobuf::Message *message, Local<Object> subj, bool p
 			Local<Object> array;
 		        if (val->IsArray()) {
 			        len = val.As<Array>()->Length();
+#if NODE_MAJOR_VERSION > 0
 			} else if (val->IsTypedArray()) {
 			        len = val.As<TypedArray>()->Length();
+#endif
 			} else {
 			        continue;
 			}

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1,7 +1,7 @@
 #ifndef SERIALIZE_H
 #define SERIALIZE_H
 
-void SerializeField(google::protobuf::Message *message, const Reflection *r, const FieldDescriptor *field, Handle<Value> val, bool preserve_int64);
-int SerializePart(google::protobuf::Message *message, Handle<Object> subj, bool preserve_int64);
+void SerializeField(google::protobuf::Message *message, const Reflection *r, const FieldDescriptor *field, Local<Value> val, bool preserve_int64);
+int SerializePart(google::protobuf::Message *message, Local<Object> subj, bool preserve_int64);
 
 #endif

--- a/test/test.js
+++ b/test/test.js
@@ -109,6 +109,8 @@ describe("Basic", function() {
 			assert.deepEqual(objWithNull, parsed)
 		})
 
+		// Typed arrays are hilariously broken before 0.12
+		if (Number(process.version.match(/^v(\d+\.\d+)/)[1]) > 0.11)
 		it("Should return repeated int32 fields as typed array", function() {
 			var obj = {
 				"name": "test",

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,19 @@ describe("Basic", function() {
 			delete objWithNull.value;
 			assert.deepEqual(objWithNull, parsed)
 		})
+
+		it("Should return repeated int32 fields as typed array", function() {
+			var obj = {
+				"name": "test",
+				"n64": 123,
+			        "r": new Int32Array([1,2,3,4])
+			}
+
+			var buffer = pb.serialize(obj, "tk.tewi.Test")
+			var parsed = pb.parse(buffer, "tk.tewi.Test")
+
+			assert.deepEqual(obj.r, parsed.r)
+		})
 	})
 
 	describe("Info", function() {


### PR DESCRIPTION
I am using node-protobuf to parse caffe models and without supporting typed arrays node tends to run out of memory for large models. This also adds support to serializing typed arrays, which is probably generally useful as well.