### PR TITLE
use named args, improves perf of parse and serialize by 5-8%

### DIFF
--- a/protobuf.js
+++ b/protobuf.js
@@ -35,21 +35,18 @@ function pb_wrapper() {
   this.native = new protobuf.native(descriptor, int64);
 }
 
-pb_wrapper.prototype.parse = function() {
-  if (arguments.length < 2)
+pb_wrapper.prototype.parse = function(buffer, schema, callback, limit, warn) {
+  if (!buffer || !schema)
     throw new Error("Invalid arguments");
-
-  var buffer = arguments[0];
-  var schema = arguments[1];
-  var callback = arguments[2] || null;
-  var limit = arguments[3] | 0;
-  var warn = arguments[4] | 0;
-  var native = this.native;
 
   if (!Buffer.isBuffer(buffer))
     throw new Error("First argument must be a Buffer");
 
-  if (callback === null) {
+  limit = limit | 0;
+  warn = warn | 0;
+  var native = this.native;
+
+  if (!callback) {
     var result = native.parse(buffer, schema, limit, warn);
     if (result === null)
       throw new Error("Unexpected error while parsing " + schema);
@@ -66,21 +63,18 @@ pb_wrapper.prototype.parse = function() {
     })
 };
 
-pb_wrapper.prototype.parseWithUnknown = function() {
-  if (arguments.length < 2)
+pb_wrapper.prototype.parseWithUnknown = function(buffer, schema, callback, limit, warn) {
+  if (!buffer || !schema)
     throw new Error("Invalid arguments");
-
-  var buffer = arguments[0];
-  var schema = arguments[1];
-  var callback = arguments[2] || null;
-  var limit = arguments[3] | 0;
-  var warn = arguments[4] | 0;
-  var native = this.native;
 
   if (!Buffer.isBuffer(buffer))
     throw new Error("First argument must be a Buffer");
 
-  if (callback === null) {
+  limit = limit | 0;
+  warn = warn | 0;
+  var native = this.native;
+
+  if (!callback) {
     var result = native.parseWithUnknown(buffer, schema, limit, warn);
     if (result === null)
       throw new Error("Unexpected error while parsing " + schema);
@@ -97,16 +91,13 @@ pb_wrapper.prototype.parseWithUnknown = function() {
     })
 };
 
-pb_wrapper.prototype.serialize = function() {
-  if (arguments.length < 2)
+pb_wrapper.prototype.serialize = function(object, schema, callback) {
+  if (!object || !schema)
     throw new Error("Invalid arguments");
 
-  var object = arguments[0];
-  var schema = arguments[1];
-  var callback = arguments[2] || null;
   var native = this.native;
 
-  if (callback === null) {
+  if (!callback) {
     var result = native.serialize(object, schema);
     if (result === null)
       throw new Error("Missing required fields while serializing " + schema);


### PR DESCRIPTION
Using named arguments on the protobuf.js wrapper instead of the `arguments` expression improves performance by a small but noticeable amount.

before:
$ node test/perf/perfTest.js
serializing and parsing a message 1,000,000 times...
serialize: 8876ms
parse: 8054ms

after:
$ node test/perf/perfTest.js
serializing and parsing a message 1,000,000 times...
serialize: 8378ms # 5% faster
parse: 7713ms     # 4% faster

There's variance in the output, sometimes showing an 8% difference, but it's always faster. I noticed this when doing profiling of an application we are building, where protobuf parsing and serialization is where most of the work is. Our app needs to be very highly performant so this makes a big difference.