### PR TITLE
adds a memory_leak reproduction script

### DIFF
--- a/test/memory_leak.js
+++ b/test/memory_leak.js
@@ -1,0 +1,25 @@
+var fs = require("fs")
+
+var p = require("../protobuf")
+
+var obj = {
+	"name": "testtesttesttesttest",
+	"n64": 123,
+	"r": []
+}
+
+var heapUsed;
+var last = 0;
+var desc = fs.readFileSync(__dirname + "/test.desc");
+
+function run() {
+	var rss = process.memoryUsage().rss;
+	console.error('RSS: ' + rss + ', Delta: ' + (rss-last));
+	last = rss;
+
+	for (let i = 0; i < 2000; i++) {
+		var pb = new p(desc);
+	}					
+	setTimeout(run, 500);
+}
+run();


### PR DESCRIPTION
No need to merge. Just adds a script that can be used to demonstrate a memory leak. The output of the script for me looks like:

```:node-protobuf dareed$ node test/memory_leak.js
RSS: 17182720, Delta: 17182720
RSS: 38141952, Delta: 20959232
RSS: 57458688, Delta: 19316736
RSS: 76390400, Delta: 18931712
RSS: 96145408, Delta: 19755008
RSS: 114917376, Delta: 18771968
RSS: 133206016, Delta: 18288640
RSS: 152915968, Delta: 19709952
RSS: 171692032, Delta: 18776064
RSS: 190488576, Delta: 18796544
RSS: 209526784, Delta: 19038208
RSS: 228552704, Delta: 19025920
RSS: 247595008, Delta: 19042304
RSS: 266752000, Delta: 19156992
RSS: 282992640, Delta: 16240640
<snip>
```
It continuously goes up without bound.