### PR TITLE
Fix potential segfault

### DIFF
--- a/run_leak.sh
+++ b/run_leak.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+node --expose-gc src/leak.js

--- a/src/leak.js
+++ b/src/leak.js
@@ -1,6 +1,7 @@
-var fs = require("fs")
+var fs = require("fs");
 
-var p = require("../protobuf")
+var p = require("../protobuf");
+var t = require('assert');
 
 var obj = {
 	"name": "testtesttesttesttest",
@@ -10,16 +11,42 @@ var obj = {
 
 var heapUsed;
 var last = 0;
-var desc = fs.readFileSync(__dirname + "/test.desc");
+var desc = fs.readFileSync(__dirname + "/../test/test.desc");
+var otherdesc = fs.readFileSync(__dirname + '/../test/testUnknown.desc');
 
 function run() {
 	var rss = process.memoryUsage().rss;
 	console.error('RSS: ' + rss + ', Delta: ' + (rss-last));
 	last = rss;
+	let x;
+	let xdecoded;
 
 	for (let i = 0; i < 2000; i++) {
-		var pb = new p(desc);
+		{
+			// Put this in an isolated scope so we can gc it properly.
+			var pb = new p(desc);
+			x = pb.serialize({
+				lies: 'hey',
+				n64: 121,
+				name: 'yeah'
+			}, 'tk.tewi.Test');
+			xdecoded = pb.parse(x, 'tk.tewi.Test');
+			try {
+				pb.parse(null, 'tk.tewi.Test');
+			} catch (e) {}
+		}
+		{
+			var pb = new p(otherdesc);
+			x = pb.serialize({
+				lies: 'hey',
+				n64: 121,
+				name: 'yeah'
+			}, 'tk.tewi.Test');
+			xdecoded = pb.parse(x, 'tk.tewi.Test');
+		}
+		global.gc();
 	}
-	setTimeout(run, 500);
+
+	setImmediate(run);
 }
 run();

--- a/src/native.h
+++ b/src/native.h
@@ -6,16 +6,14 @@
 class NativeProtobuf : public Nan::ObjectWrap {
 public:
   static void Init(Local<Object> exports);
-  NativeProtobuf(DescriptorPool *pool, std::vector<std::string> info,
-                 bool preserve_int64);
-  ~NativeProtobuf();
+  NativeProtobuf(FileDescriptorSet *descriptors, bool preserve_int64);
 
-  DescriptorPool *pool;
+  DescriptorPool pool;
   std::vector<std::string> info;
   bool preserve_int64;
 
 private:
-  static DynamicMessageFactory factory;
+  DynamicMessageFactory factory;
   static NAN_METHOD(New);
   static NAN_METHOD(Parse);
   static NAN_METHOD(ParseWithUnknown);


### PR DESCRIPTION
There is a potential collision with the DynamicMessageFactory since it is statically scoped. If a new object is created with a different proto that has the same name as another, the factory strips it from the cache (as far as I can tell). However, descriptors generated from it still live within a pool, which tries to clean up, but now has invalid pointers.

By making the factory locally scoped, other encoders cannot affect this, which seems to stop the segfaults.

Additionally, had to make it so it was stack allocated rather than heap allocated, which required me to change the constructor slightly.