### PR TITLE
Remain unset optional fields with their default values.

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -280,9 +280,6 @@ Local<Object> ParsePart(Isolate *isolate,
 
     if (field != NULL) {
 
-      if (field->is_optional() && !r->HasField(message, field))
-        continue;
-
       Local<Value> v;
 
       if (field->is_repeated()) {


### PR DESCRIPTION
Hi, in [protobuf3](https://developers.google.com/protocol-buffers/docs/proto3), there are no required fields anymore. For numeric fields with value 0, the filed is serialized as unset and in this case, the parsed object will lack such fields. This patch removed detection for fields which are not present and let libprotobuf return the default value, as expected.